### PR TITLE
remove duplicate sound id

### DIFF
--- a/esoui/libraries/globals/soundids.lua
+++ b/esoui/libraries/globals/soundids.lua
@@ -784,9 +784,8 @@ SOUNDS =
 
     DYEING_TOOL_DYE_USED                    = "Dyeing_Tool_Dye_Used",
     DYEING_TOOL_ERASE_USED                  = "Dyeing_Tool_Erase_Used",
-    DYEING_TOOL_FILL_USED                   = "Dyeing_Tool_Fill_Used",
-    DYEING_TOOL_SAMPLE_USED                 = "Dyeing_Tool_Sample_Used",
     DYEING_TOOL_FILL_USED                   = "Dyeing_Tool_Fill_All_Used",
+    DYEING_TOOL_SAMPLE_USED                 = "Dyeing_Tool_Sample_Used",
     DYEING_TOOL_SET_FILL_USED               = "Dyeing_Tool_Set_Fill_Used",
 
     DYEING_SWATCH_SELECTED                  = "Dyeing_Swatch_Selected",


### PR DESCRIPTION
`DYEING_TOOL_FILL_USED` is currently being assigned 2 different values - I verified that `"Dyeing_Tool_Fill_All_Used"` was the correct value and removed the other assignment.
But how did that even happen lol?